### PR TITLE
review comments for man page

### DIFF
--- a/man/pkcs11sign.7
+++ b/man/pkcs11sign.7
@@ -9,7 +9,7 @@ provides cryptographic operation on asymmetric key material, available in
 PKCS#11 infrastructure (e.g. opencryptoki). The pkcs11-sign-provider will
 register a key storage for PKCS#11 URIs (RFC 7512). All keys which are
 referenced by a PKCS#11 URI will be handled by the pkcs11-sign-provider.
-Other keys (e.g.  file-based) are are forwarded by the pkcs11-sign-provider
+Other keys (e.g.  file-based) are forwarded by the pkcs11-sign-provider
 to another OpenSSL-Provider, e.g. the built-in OpenSSL default provider.
 .PP
 The pkcs11-sign-provider will only process algorithms with existing
@@ -91,7 +91,7 @@ file, which contains the PIN. It is highly recommended to use the file
 reference and set the access permissions of the PIN file accordingly.
 .PP
 .SS PIN file
-The PIN gives access to a PKCS#11 token and its objects (keys, certificated,
+The PIN gives access to a PKCS#11 token and its objects (keys, certificates,
 data). It should be treated as a secret information and only the application
 should have access to it. With the right setup, the usage of a PIN file
 provides the best protection for the PIN.

--- a/man/pkcs11sign.cnf.5
+++ b/man/pkcs11sign.cnf.5
@@ -67,11 +67,6 @@ Cryptoki module implementation. The provider can be used with PKCS#11
 Cryptoki modules, implementing the PKCS#11 standard version 3.0 (or
 compatible).
 .TP
-.BR pkcs11sign-module-init-args " (optional)"
-The pkcs11sign-module-init-args takes a parameter string, which is used
-during the initialization of the Cryptoki module.
-.PP
-.TP
 .BR pkcs11sign-forward " (optional)"
 The pkcs11sign-forward parameter takes the name of a provider, to which all
 operations are forwarded, which are not handled by the pkcs11-sign-provider
@@ -82,17 +77,35 @@ default provider as forward.
 The syntax for this parameter is "provider=<name_of_forward_provider>". See
 the configuration example for more details.
 .PP
+.TP
+.BR pkcs11sign-module-init-args " (optional, not PKCS#11-3.0 conform)"
+The pkcs11sign-module-init-args takes a parameter string whose
+reference is passed to the Cryptoki module as
+.IR pReserved " in"
+.IR CK_C_INITIALIZE_ARGS
+during initialization.
+.IP
+Note: The PKCS#11 standard v3.0 specifies that the initialization of a
+Cryptoki module fails if
+.IR pReserved
+is not a NULL_PTR. This parameter will only work with Cryptoki modules
+(e.g.  libnss) which do not implement this strict behavior. A Cryptoki
+module, which strictly implements the PKCS#11 standard v3.0 will fail
+on
+.IR C_Initialize() " with"
+.IR CKR_ARGUMENTS_BAD
+if this parameter is set.
+.PP
 
 .SS EVP Configuration (alg_section)
-This section configures the algorithmic properties for the EVP API. The
+This section configures the algorithm-properties for the EVP API. The
 pkcs11-sign-provider should be set as the preferred provider for all EVP
-algorithms by adding the
-.I default_properties
-the expresstion "?provider=pkcs11sign".
+algorithms by adding the expression "?provider=pkcs11sign" to the
+.IR default_properties .
 .PP
 
 .SS Configuration example
-This configuration example shows
+This example shows a pkcs11-sign-provider configuration for opencryptoki.
 .in +4n
 .EX
 openssl_conf = openssl_init


### PR DESCRIPTION
This PR includes review comments. Beside typos and other minor corrections, it also contains a reference to non-standard conform usage of the initialization arguments.