### PR TITLE
pkcs11: Allow CKR_CRYPTOKI_ALREADY_INITIALIZED with C_Initialize

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -38,6 +38,7 @@ struct pkcs11_module {
 		PKCS11_INITIALIZED,
 	} state;
 	unsigned int refcnt;
+	bool do_finalize;
 };
 
 struct ossl_provider {

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -572,6 +572,10 @@ static int ps_keymgmt_export(void *vkey, int selection,
 	ps_obj_debug(key, "key: %p selection: %d",
 		     key, selection);
 
+	if (key->use_pkcs11 &&
+	    (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY))
+		return OSSL_RV_ERR;
+
 	if (ps_keymgmt_export_fwd(key, selection,
 				  param_callback, cbarg) != OSSL_RV_OK) {
 		ps_obj_debug(key, "ps_keymgmt_export_fwd() failed");

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -261,13 +261,18 @@ void pkcs11_attrs_deepfree(CK_ATTRIBUTE_PTR attributes, CK_ULONG nattributes)
 
 CK_RV pkcs11_attr_dup(const CK_ATTRIBUTE_PTR src, CK_ATTRIBUTE_PTR dst)
 {
-	if (!src || !dst ||
-	    !src->pValue || !src->ulValueLen)
+	if (!src || !dst)
 		return CKR_ARGUMENTS_BAD;
 
-	dst->pValue = OPENSSL_memdup(src->pValue, src->ulValueLen);
-	if (!dst->pValue)
-		return CKR_HOST_MEMORY;
+	if (src->ulValueLen > 0) {
+		if (!src->pValue)
+			return CKR_ARGUMENTS_BAD;
+		dst->pValue = OPENSSL_memdup(src->pValue, src->ulValueLen);
+		if (!dst->pValue)
+			return CKR_HOST_MEMORY;
+	} else {
+		dst->pValue = NULL;
+	}
 
 	dst->type = src->type;
 	dst->ulValueLen = src->ulValueLen;


### PR DESCRIPTION
The provider initializes the PKCS#11 library using C_Initialize during provider initialization. If this fails, then the provider fails to initialize and is not available.

There are situations where applications first initialize the PKCS#11 library themselves, and then load the provider, e.g. due to explicit or implicit OpenSSL initialization which loads the provider. In such cases the provider's C_Initialize will fail with CKR_CRYPTOKI_ALREADY_INITIALIZED.

Ignore this error situation, because the PKCS#11 library is already initialized, and thus the provider can simply continue and call further PKCS#11 services. However, in such case, the provider should also not call C_Finalize during its teardown, but leave it to the application to finalize the PKCS#11 library.