### PR TITLE
Add fork support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tests/tmp.*
 tests/ttls
 tests/tsignature
 tests/tecdhe
+tests/tfork
 *.log
 *.trs
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ pkcs11sign_la_SOURCES = \
 	signature.c signature.h \
 	asym.c asym.h \
 	keyexch.c keyexch.h \
+	fork.c fork.h \
 	common.c common.h \
 	consttime.h
 

--- a/src/common.h
+++ b/src/common.h
@@ -32,6 +32,7 @@ typedef void (*func_t)(void);
 struct pkcs11_module {
 	char *soname;
 	void *dlhandle;
+	char *initargs;
 	CK_FUNCTION_LIST *fns;
 	enum PKCS11_STATE {
 		PKCS11_UNINITIALIZED = 0,

--- a/src/common.h
+++ b/src/common.h
@@ -38,6 +38,7 @@ struct pkcs11_module {
 		PKCS11_UNINITIALIZED = 0,
 		PKCS11_INITIALIZED,
 	} state;
+	pthread_mutex_t mutex;
 	bool do_finalize;
 };
 

--- a/src/fork.c
+++ b/src/fork.c
@@ -1,0 +1,433 @@
+#include <unistd.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "pkcs11.h"
+#include "common.h"
+#include "debug.h"
+#include "fork.h"
+
+static struct {
+	pthread_mutex_t mutex;
+	bool registered;
+
+	struct pkcs11_module **pkcss;
+	unsigned int pkcs_num;
+	unsigned int pkcs_size;
+
+	CK_OBJECT_HANDLE_PTR *ohs;
+	unsigned int oh_num;
+	unsigned int oh_size;
+
+	CK_SESSION_HANDLE_PTR *shs;
+	unsigned int sh_num;
+	unsigned int sh_size;
+} atfork_pool = {
+	.mutex = PTHREAD_MUTEX_INITIALIZER,
+	.registered = false,
+};
+
+static void fork_prepare(void)
+{
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		fprintf(stderr, "pid %d: unable to lock atfork pool\n",
+			getpid());
+		return;
+	}
+
+	/* ----- locked ----- */
+}
+
+static void fork_parent(void)
+{
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		fprintf(stderr, "pid %d: unable to unlock pool (parent)\n",
+			getpid());
+		return;
+	}
+
+	/* ----- unlocked ----- */
+}
+
+static void fork_child(void)
+{
+	struct pkcs11_module *pkcs;
+	unsigned int i;
+
+	for(i = 0; i < atfork_pool.oh_size; i++) {
+		if (atfork_pool.ohs[i])
+			*atfork_pool.ohs[i] = CK_INVALID_HANDLE;
+	}
+
+	for(i = 0; i < atfork_pool.sh_size; i++) {
+		if (atfork_pool.shs[i])
+			*atfork_pool.shs[i] = CK_INVALID_HANDLE;
+	}
+
+	for(i = 0; i < atfork_pool.pkcs_size; i++) {
+		pkcs = atfork_pool.pkcss[i];
+		if (pkcs)
+			pkcs->state = PKCS11_UNINITIALIZED;
+	}
+
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		fprintf(stderr, "pid %d: unable to unlock pool (child)\n",
+			getpid());
+		return;
+	}
+
+	/* ----- unlocked ----- */
+	return;
+}
+
+static int _pthread_atfork_once(void) {
+	if (atfork_pool.registered)
+		return OSSL_RV_OK;
+
+	if (pthread_atfork(fork_prepare, fork_parent, fork_child))
+		return OSSL_RV_ERR;
+	atfork_pool.registered = true;
+
+	return OSSL_RV_OK;
+}
+
+static int _gen_alloc(void **pool, unsigned int *num, unsigned int *size,
+		      size_t elem_size, int elem_num)
+{
+	size_t bytes = elem_size * elem_num;
+	void *tmp;
+
+	/* initial allocation */
+	if (!(*num)) {
+		tmp = OPENSSL_zalloc(bytes);
+		if (!tmp)
+			return OSSL_RV_ERR;
+
+		*pool = tmp;
+		*size += elem_num;
+	}
+
+	/* grow (if required) */
+	if (*num && (*num % elem_num == 0)) {
+		tmp = OPENSSL_realloc(*pool, *num + (bytes));
+		if (!tmp)
+			return OSSL_RV_ERR;
+
+		memset(tmp + (elem_size * *num), 0, bytes);
+		*pool = tmp;
+		*size += elem_num;
+	}
+
+	return OSSL_RV_OK;
+}
+
+static void _gen_free(void **pool, unsigned int *num, unsigned int *size)
+{
+	if (*num)
+		return;
+
+	OPENSSL_free(*pool);
+	*pool = NULL;
+	*size = 0;
+}
+
+#define AFP_PKCS_POOL	8
+int atforkpool_register_pkcs11(struct pkcs11_module *pkcs, struct dbg *dbg)
+{
+	int rc = OSSL_RV_ERR;
+	bool found = false;
+	unsigned int i;
+
+	if (!pkcs)
+		return OSSL_RV_OK;
+	if (!dbg)
+		return OSSL_RV_ERR;
+
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "pkcs: %p, lock atfork pool failed", pkcs);
+		return OSSL_RV_ERR;
+	}
+
+	/* ----- locked ----- */
+	if (_gen_alloc((void **)&atfork_pool.pkcss, &atfork_pool.pkcs_num, &atfork_pool.pkcs_size,
+		       sizeof(struct pkcs11 *), AFP_PKCS_POOL) != OSSL_RV_OK) {
+		ps_dbg_error(dbg, "pkcs: %p, pkcs pool allocation failed", pkcs);
+		goto unlock_out;
+	}
+
+	for (i = 0; i < atfork_pool.pkcs_size; i++) {
+		if (atfork_pool.pkcss[i] == NULL) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		ps_dbg_error(dbg, "pkcs: %p, unable to register", pkcs);
+		goto unlock_out;
+	}
+
+	atfork_pool.pkcss[i] = pkcs;
+	atfork_pool.pkcs_num++;
+
+	if (_pthread_atfork_once() != OSSL_RV_OK) {
+		ps_dbg_warn(dbg, "unable to register fork handler");
+		goto unlock_out;
+	}
+
+	rc = OSSL_RV_OK;
+unlock_out:
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "pkcs: %p, unlock atfork pool failed", pkcs);
+		return OSSL_RV_ERR;
+	}
+	/* ----- unlocked ----- */
+	ps_dbg_debug(dbg, "pkcs: %p, registered in atfork pool", pkcs);
+	return rc;
+}
+
+int atforkpool_unregister_pkcs11(struct pkcs11_module *pkcs, struct dbg *dbg)
+{
+	int rc = OSSL_RV_ERR;
+	bool found = false;
+	unsigned int i;
+
+	if (!pkcs)
+		return OSSL_RV_OK;
+	if (!dbg)
+		return OSSL_RV_ERR;
+
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "pkcs: %p, lock atfork pool failed", pkcs);
+		return OSSL_RV_ERR;
+	}
+
+	/* ----- locked ----- */
+	for (i = 0; i < atfork_pool.pkcs_size; i++) {
+		if (atfork_pool.pkcss[i] == pkcs) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		ps_dbg_error(dbg, "pkcs: %p, unable to unregister", pkcs);
+		goto unlock_out;
+	}
+
+	atfork_pool.pkcss[i] = NULL;
+	atfork_pool.pkcs_num--;
+
+	_gen_free((void **)&atfork_pool.pkcss, &atfork_pool.pkcs_num,
+		  &atfork_pool.pkcs_size);
+	rc = OSSL_RV_OK;
+unlock_out:
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "pkcs: %p, unlock atfork pool failed", pkcs);
+		return OSSL_RV_ERR;
+	}
+	/* ----- unlocked ----- */
+	ps_dbg_debug(dbg, "pkcs: %p, unregistered in atfork pool", pkcs);
+	return rc;
+}
+
+#define AFP_OH_POOL	16
+int atforkpool_register_objecthandle(CK_OBJECT_HANDLE_PTR poh, struct dbg *dbg)
+{
+	int rc = OSSL_RV_ERR;
+	bool found = false;
+	unsigned int i;
+
+	if (!poh)
+		return OSSL_RV_OK;
+	if (!dbg)
+		return OSSL_RV_ERR;
+
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "poh: %p, lock atfork pool failed", poh);
+		return OSSL_RV_ERR;
+	}
+
+	/* ----- locked ----- */
+	if (_gen_alloc((void **)&atfork_pool.ohs,
+		       &atfork_pool.oh_num, &atfork_pool.oh_size,
+		       sizeof(CK_OBJECT_HANDLE_PTR), AFP_OH_POOL) != OSSL_RV_OK) {
+		ps_dbg_error(dbg, "poh: %p, poh pool allocation failed", poh);
+		goto unlock_out;
+	}
+
+	for (i = 0; i < atfork_pool.oh_size; i++) {
+		if (atfork_pool.ohs[i] == NULL) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		ps_dbg_error(dbg, "poh: %p, unable to register", poh);
+		goto unlock_out;
+	}
+
+	atfork_pool.ohs[i] = poh;
+	atfork_pool.oh_num++;
+
+	if (_pthread_atfork_once() != OSSL_RV_OK) {
+		ps_dbg_warn(dbg, "unable to register fork handler");
+		goto unlock_out;
+	}
+
+	rc = OSSL_RV_OK;
+unlock_out:
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "poh: %p, unlock atfork pool failed", poh);
+		return OSSL_RV_ERR;
+	}
+	/* ----- unlocked ----- */
+	ps_dbg_debug(dbg, "poh: %p, registered in atfork pool", poh);
+	return rc;
+}
+
+int atforkpool_unregister_objecthandle(CK_OBJECT_HANDLE_PTR poh, struct dbg *dbg)
+{
+	int rc = OSSL_RV_ERR;
+	bool found = false;
+	unsigned int i;
+
+	if (!poh)
+		return OSSL_RV_OK;
+	if (!dbg)
+		return OSSL_RV_ERR;
+
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "poh: %p, lock atfork pool failed", poh);
+		return OSSL_RV_ERR;
+	}
+
+	/* ----- locked ----- */
+	for (i = 0; i < atfork_pool.oh_size; i++) {
+		if (atfork_pool.ohs[i] == poh) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		ps_dbg_error(dbg, "poh: %p, unable to unregister", poh);
+		goto unlock_out;
+	}
+
+	atfork_pool.ohs[i] = NULL;
+	atfork_pool.oh_num--;
+
+	_gen_free((void **)&atfork_pool.ohs, &atfork_pool.oh_num,
+		  &atfork_pool.oh_size);
+	rc = OSSL_RV_OK;
+unlock_out:
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "poh: %p, unlock atfork pool failed", poh);
+		return OSSL_RV_ERR;
+	}
+	/* ----- unlocked ----- */
+	ps_dbg_debug(dbg, "poh: %p, unregistered in atfork pool", poh);
+	return rc;
+}
+
+#define AFP_SH_POOL	16
+int atforkpool_register_sessionhandle(CK_SESSION_HANDLE_PTR psh, struct dbg *dbg)
+{
+	int rc = OSSL_RV_ERR;
+	bool found = false;
+	unsigned int i;
+
+	if (!psh)
+		return OSSL_RV_OK;
+	if (!dbg)
+		return OSSL_RV_ERR;
+
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "psh: %p, lock atfork pool failed", psh);
+		return OSSL_RV_ERR;
+	}
+
+	/* ----- locked ----- */
+	if (_gen_alloc((void **)&atfork_pool.shs, &atfork_pool.sh_num, &atfork_pool.sh_size,
+		       sizeof(CK_SESSION_HANDLE_PTR), AFP_SH_POOL) != OSSL_RV_OK) {
+		ps_dbg_error(dbg, "psh: %p, sh pool allocation failed", psh);
+		goto unlock_out;
+	}
+
+	for (i = 0; i < atfork_pool.sh_size; i++) {
+		if (atfork_pool.shs[i] == NULL) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		ps_dbg_error(dbg, "psh: %p, unable to register", psh);
+		goto unlock_out;
+	}
+
+	atfork_pool.shs[i] = psh;
+	atfork_pool.sh_num++;
+
+	if (_pthread_atfork_once() != OSSL_RV_OK) {
+		ps_dbg_warn(dbg, "unable to register fork handler");
+		goto unlock_out;
+	}
+
+	rc = OSSL_RV_OK;
+unlock_out:
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "psh: %p, unlock atfork pool failed", psh);
+		return OSSL_RV_ERR;
+	}
+	/* ----- unlocked ----- */
+	ps_dbg_debug(dbg, "psh: %p, registered in atfork pool", psh);
+	return rc;
+}
+
+int atforkpool_unregister_sessionhandle(CK_SESSION_HANDLE_PTR psh, struct dbg *dbg)
+{
+	int rc = OSSL_RV_ERR;
+	bool found = false;
+	unsigned int i;
+
+	if (!psh)
+		return OSSL_RV_OK;
+	if (!dbg)
+		return OSSL_RV_ERR;
+
+	if (pthread_mutex_lock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "psh: %p, lock atfork pool failed", psh);
+		return OSSL_RV_ERR;
+	}
+
+	/* ----- locked ----- */
+	for (i = 0; i < atfork_pool.sh_size; i++) {
+		if (atfork_pool.shs[i] == psh) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		ps_dbg_error(dbg, "psh: %p, unable to unregister", psh);
+		goto unlock_out;
+	}
+
+	atfork_pool.shs[i] = NULL;
+	atfork_pool.sh_num--;
+
+	_gen_free((void **)&atfork_pool.shs, &atfork_pool.sh_num,
+		  &atfork_pool.sh_size);
+	rc = OSSL_RV_OK;
+unlock_out:
+	if (pthread_mutex_unlock(&atfork_pool.mutex)) {
+		ps_dbg_error(dbg, "psh: %p, unlock atfork pool failed", psh);
+		return OSSL_RV_ERR;
+	}
+	/* ----- unlocked ----- */
+	ps_dbg_debug(dbg, "psh: %p, unregistered in atfork pool", psh);
+	return rc;
+}

--- a/src/fork.h
+++ b/src/fork.h
@@ -1,0 +1,13 @@
+#ifndef _FORK_H
+#define _FORK_H
+
+int atforkpool_register_pkcs11(struct pkcs11_module *pkcs, struct dbg *dbg);
+int atforkpool_unregister_pkcs11(struct pkcs11_module *pkcs, struct dbg *dbg);
+
+int atforkpool_register_objecthandle(CK_OBJECT_HANDLE_PTR poh, struct dbg *dbg);
+int atforkpool_unregister_objecthandle(CK_OBJECT_HANDLE_PTR poh, struct dbg *dbg);
+
+int atforkpool_register_sessionhandle(CK_SESSION_HANDLE_PTR psh, struct dbg *dbg);
+int atforkpool_unregister_sessionhandle(CK_SESSION_HANDLE_PTR psh, struct dbg *dbg);
+
+#endif /* _FORK_H */

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -717,6 +717,9 @@ void pkcs11_module_teardown(struct pkcs11_module *pkcs)
 	OPENSSL_free(pkcs->soname);
 	pkcs->soname = NULL;
 
+	OPENSSL_free(pkcs->initargs);
+	pkcs->initargs = NULL;
+
 	pkcs->state = PKCS11_UNINITIALIZED;
 }
 
@@ -737,6 +740,8 @@ int pkcs11_module_init(struct pkcs11_module *pkcs,
 	char *err;
 
 	pkcs->soname = OPENSSL_strdup(module);
+	if (module_initargs)
+		pkcs->initargs = OPENSSL_strdup(module_initargs);
 
 	dlerror();
 	pkcs->dlhandle = dlopen(module,

--- a/src/pkcs11.h
+++ b/src/pkcs11.h
@@ -71,7 +71,7 @@ CK_RV pkcs11_get_slots(struct pkcs11_module *pkcs,
 		       struct dbg *dbg);
 
 void pkcs11_module_teardown(struct pkcs11_module *pkcs);
-int pkcs11_module_init(struct pkcs11_module *pkcs,
+int pkcs11_module_load(struct pkcs11_module *pkcs,
 		       const char *module, const char *module_initargs,
 		       struct dbg *dbg);
 

--- a/src/provider.c
+++ b/src/provider.c
@@ -300,9 +300,9 @@ static int ps_prov_init(const OSSL_CORE_HANDLE *handle,
 	}
 	ps_pctx_debug(pctx, "pctx: %p, forward: %s", pctx, pctx->fwd.name);
 
-	if (pkcs11_module_init(&pctx->pkcs11, module, module_args, &pctx->dbg) != OSSL_RV_OK) {
+	if (pkcs11_module_load(&pctx->pkcs11, module, module_args, &pctx->dbg) != OSSL_RV_OK) {
 		put_error_pctx(pctx, PS_ERR_INTERNAL_ERROR,
-			       "Failed to initialize pkcs11 module %s", module);
+			       "Failed to load pkcs11 module %s", module);
 		goto err;
 	}
 	ps_pctx_debug(pctx, "pctx: %p, pkcs11: %s", pctx, pctx->pkcs11.soname);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@
 libspath=@abs_top_builddir@/src/.libs
 testsdir=@abs_srcdir@
 
-check_PROGRAMS = ttls tsignature tecdhe
+check_PROGRAMS = ttls tsignature tecdhe tfork
 
 ttls_SOURCES = ttls.c utils.c utils.h
 ttls_CFLAGS = $(AM_CFLAGS) $(STD_CFLAGS) $(OPENSSL_CFLAGS)
@@ -18,6 +18,10 @@ tecdhe_SOURCES = tecdhe.c utils.c utils.h
 tecdhe_CFLAGS = $(AM_CFLAGS) $(STD_CFLAGS) $(OPENSSL_CFLAGS)
 tecdhe_LDADD = $(OPENSSL_LIBS)
 
+tfork_SOURCES = tfork.c utils.c utils.h
+tfork_CFLAGS = $(AM_CFLAGS) $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+tfork_LDADD = $(OPENSSL_LIBS)
+
 setup_scripts =
 setup_scripts += helpers.sh
 setup_scripts += setup-ock.sh
@@ -27,7 +31,7 @@ tmp.ock:
 	TESTSDIR=$(testsdir) \
 	$(testsdir)/setup-ock.sh > setup-ock.log 2>&1
 
-TESTS = openssl-ock tls-ock signature-ock ecdhe-ock
+TESTS = openssl-ock tls-ock signature-ock ecdhe-ock fork-ock
 
 $(TESTS): tmp.ock
 

--- a/tests/tfork.c
+++ b/tests/tfork.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) IBM Corp. 2022, 2023
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/store.h>
+
+#include "utils.h"
+
+#define EXIT_SKIP	(77)
+
+static EVP_MD_CTX *create_context(void)
+{
+	EVP_MD_CTX *ctx;
+
+	ctx = EVP_MD_CTX_create();
+	if (!ctx) {
+		fprintf(stderr, "fail: EVP_MD_CTX_create()\n");
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+
+	return ctx;
+}
+
+static void configure_sign_context(EVP_MD_CTX *ctx, EVP_PKEY *pkey, const char *key_info)
+{
+	if (EVP_DigestSignInit(ctx, NULL, EVP_sha256(), NULL, pkey) != 1) {
+		fprintf(stderr, "fail: EVP_DigestSignInit() [ctx=%p, key_info=%s]\n",
+			ctx, key_info);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void configure_verify_context(EVP_MD_CTX *ctx, EVP_PKEY *pkey, const char *key_info)
+{
+	if (EVP_DigestVerifyInit(ctx, NULL, EVP_sha256(), NULL, pkey) != 1) {
+		fprintf(stderr, "fail: EVP_DigestVerifyInit() [ctx=%p, key_info=%s]\n",
+			ctx, key_info);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static size_t sign_get_length(EVP_MD_CTX *ctx)
+{
+	size_t len;
+
+	if (EVP_DigestSignFinal(ctx, NULL, &len) != 1) {
+		fprintf(stderr, "fail: EVP_DigestSignFinal() [ctx=%p]\n",
+			ctx);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+	return len;
+}
+
+static void sign_msg(EVP_MD_CTX *ctx, const char *msg, size_t msglen,
+		     unsigned char *s, size_t slen, size_t *len)
+{
+	size_t _len = slen;
+
+	if (EVP_DigestSignUpdate(ctx, msg, msglen) != 1) {
+		fprintf(stderr, "fail: EVP_DigestSignUpdate() [ctx=%p]\n",
+			ctx);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+
+	if (EVP_DigestSignFinal(ctx, s, &_len) != 1) {
+		fprintf(stderr, "fail: EVP_DigestSignFinal() [ctx=%p]\n",
+			ctx);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+
+	*len = _len;
+}
+
+static void verify_msg(EVP_MD_CTX *ctx, const char *msg, size_t msglen,
+		       const unsigned char *sig, size_t siglen)
+{
+	if (EVP_DigestVerifyUpdate(ctx, msg, msglen) != 1) {
+		fprintf(stderr, "fail: EVP_DigestVerifyUpdate() [ctx=%p]\n",
+			ctx);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+
+	if (EVP_DigestVerifyFinal(ctx, sig, siglen) != 1) {
+		fprintf(stderr, "fail: EVP_DigestVerifyFinal() [ctx=%p]\n",
+			ctx);
+		ERR_print_errors_fp(stderr);
+		exit(EXIT_FAILURE);
+	}
+}
+
+void sign_verify(const char *priv, const char *cert, bool debug)
+{
+	const char *msg = "test message for sign/verify";
+	EVP_MD_CTX *sctx = NULL, *vctx = NULL;
+	unsigned char *sig;
+	EVP_PKEY *spkey, *vpkey;
+	size_t len, siglen;
+
+	/* sign */
+	sctx = create_context();
+	if (debug) fprintf(stderr, "pass: [%d] signature context creation\n", getpid());
+
+	child_propagate();
+
+	spkey = uri_pkey_get1(priv);
+	if (debug) fprintf(stderr, "pass: [%d] pkey load for signing [uri: %s, spkey: %p]\n",
+			   getpid(), priv, spkey);
+
+	child_propagate();
+
+	configure_sign_context(sctx, spkey, priv);
+	if (debug) fprintf(stderr, "pass: [%d] signature context configuration [uri: %s]\n",
+			   getpid(), priv);
+
+	child_propagate();
+
+	siglen = sign_get_length(sctx);
+	sig = OPENSSL_zalloc(siglen);
+	if (!sig)
+		exit(EXIT_FAILURE);
+
+	child_propagate();
+
+	sign_msg(sctx, msg, strlen(msg), sig, siglen, &len);
+	if (debug) fprintf(stderr, "pass: [%d] message signing [uri: %s, len: %lu]\n",
+			   getpid(), priv, len);
+
+	if (debug) fdump(stderr, sig, len);
+
+	/* verify */
+	vctx = create_context();
+	if (debug) fprintf(stderr, "pass: [%d] verify context creation\n", getpid());
+
+	child_propagate();
+
+	vpkey = uri_pkey_get1(cert);
+	if (debug) fprintf(stderr, "pass: [%d] pkey load for verify [uri: %s, vpkey: %p]\n",
+			   getpid(), cert, vpkey);
+
+	child_propagate();
+
+	configure_verify_context(vctx, vpkey, cert);
+	if (debug) fprintf(stderr, "pass: [%d] verify context configuration [uri: %s]\n",
+			   getpid(), cert);
+
+	child_propagate();
+
+	verify_msg(vctx, msg, strlen(msg), sig, len);
+	if (debug) fprintf(stderr, "pass: [%d] message verification [uri: %s]\n",
+			   getpid(), cert);
+
+	EVP_PKEY_free(spkey);
+	EVP_PKEY_free(vpkey);
+	EVP_MD_CTX_free(sctx);
+	EVP_MD_CTX_free(vctx);
+	OPENSSL_free(sig);
+}
+
+static char *test_keys[][2] = {
+	/* ecdsa */
+	{ "FILE_PEM_ECDSA_PRV", "FILE_PEM_ECDSA_CRT"},
+	{ "URI_KEY_ECDSA_PRV", "FILE_PEM_ECDSA_CRT"},
+	/* rsa */
+	{ "FILE_PEM_RSA4K_PRV", "FILE_PEM_RSA4K_CRT"},
+	{ "URI_KEY_RSA4K_PRV", "FILE_PEM_RSA4K_CRT"},
+};
+
+int main(void)
+{
+	size_t i, nelem;
+	bool debug;
+
+	debug = (getenv("PKCS11SIGN_DEBUG")) ? true : false;
+	if (debug) info();
+
+	nelem = sizeof(test_keys) / sizeof(test_keys[0]);
+	for (i = 0; i < nelem; i++) {
+		char *env_p, *env_c, *priv, *cert;
+
+		env_p = test_keys[i][0];
+		env_c = test_keys[i][1];
+
+		if (!env_p || !env_c) {
+			fprintf(stderr, "skip: [%ld] forked sign/verify with %s/%s\n",
+				i, env_p, env_c);
+			continue;
+		}
+
+		priv = getenv(env_p);
+		cert = getenv(env_c);
+
+		if (!priv || !cert) {
+			fprintf(stderr, "skip: [%ld] forked sign/verify with %s/%s\n",
+				i, env_p, env_c);
+			continue;
+		}
+
+		sign_verify(priv, cert, debug);
+		fprintf(stderr, "pass: [%ld] forked sign/verify with %s/%s\n",
+			i, env_p, env_c);
+	}
+
+	return 0;
+}

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -11,3 +11,4 @@
 void info(void);
 EVP_PKEY *uri_pkey_get1(const char *uri);
 void fdump(FILE *restrict stream, const unsigned char *p, size_t len);
+void child_propagate(void);


### PR DESCRIPTION
This PR implements the fork support for the provider (issue #2 ). It consists of:
- static pool for pkcs11 modules, object- and session handles
- atfork handler, invalidates the elements in the pools after a fork in the child
- additional testcase with forking between openssl crypto operations

Closes #2