### PR TITLE
man: escape relevant hyphen-minus characters

### DIFF
--- a/man/pkcs11sign.7
+++ b/man/pkcs11sign.7
@@ -1,22 +1,22 @@
-.TH PKCS11SIGN 7 "2022-11-21" "pkcs11sign"
+.TH PKCS11SIGN 7 "2024-05-14" "pkcs11sign"
 .SH NAME
 pkcs11sign \- OpenSSL PKCS#11 sign provider module
 .PP
 
 .SH DESCRIPTION
-The pkcs11-sign-provider implements the OpenSSL 3.0 provider interface and
+The pkcs11\-sign\-provider implements the OpenSSL 3.0 provider interface and
 provides cryptographic operation on asymmetric key material, available in
-PKCS#11 infrastructure (e.g. opencryptoki). The pkcs11-sign-provider will
+PKCS#11 infrastructure (e.g. opencryptoki). The pkcs11\-sign\-provider will
 register a key storage for PKCS#11 URIs (RFC 7512). All keys which are
-referenced by a PKCS#11 URI will be handled by the pkcs11-sign-provider.
-Other keys (e.g.  file-based) are forwarded by the pkcs11-sign-provider
+referenced by a PKCS#11 URI will be handled by the pkcs11\-sign\-provider.
+Other keys (e.g.  file-based) are forwarded by the pkcs11\-sign\-provider
 to another OpenSSL-Provider, e.g. the built-in OpenSSL default provider.
 .PP
-The pkcs11-sign-provider will only process algorithms with existing
+The pkcs11\-sign\-provider will only process algorithms with existing
 (private) asymmetric keys in the related PKCS11-token. All other actions
 will be handled by the forward-provider as clear-key operations.
 .PP
-The pkcs11-sign-provider does not support key creation or removal of PKCS#11
+The pkcs11\-sign\-provider does not support key creation or removal of PKCS#11
 keys. For key management, external tools are required.
 .PP
 Supported PKCS#11 mechanisms for RSA:
@@ -36,14 +36,14 @@ CKM_ECDSA
 
 .SH APPLICATION INTERFACE
 An application, which should use asymmetric keys in PKCS#11 infrastructure,
-must use an OpenSSL configuration for the pkcs11-sign-provider and refer to
+must use an OpenSSL configuration for the pkcs11\-sign\-provider and refer to
 the keys by an PKCS#11 URI. The rest of the application should not need any
 changes.
 .PP
 
 .SS Configuration
 If the system-wide OpenSSL configuration does not configure the
-pkcs11-sign-provider, the application can use its own OpenSSL configuration
+pkcs11\-sign\-provider, the application can use its own OpenSSL configuration
 file and refer to it in its environment variable
 .IR OPENSSL_CONF .
 For more details about the configuration see pkcs11sign.cnf(5).
@@ -52,7 +52,7 @@ For more details about the configuration see pkcs11sign.cnf(5).
 .SS Key references
 Instead of referring to a private key file (e.g. "file:/path/to/key.pem"),
 the application should use the PKCS#11 URI of the key
-("pkcs11:<path-attributes>?<queue-attributes>").
+("pkcs11:<path\-attributes>?<queue\-attributes>").
 .PP
 The PKCS#11 URI should specify path parameters of the key, at least the ID
 or label of the key, as well as its type. The key reference should be
@@ -61,16 +61,16 @@ unique.
 Example for a PKCS#11 URI to a private key:
 .in +4n
 .EX
-pkcs11:token=mytok;object=ec-key;type=private&pin-source=/path/to/token-pinfile.txt
+pkcs11:token=mytok;object=ec\-key;type=private&pin\-source=/path/to/token\-pinfile.txt
 .EE
 .in
 .PP
 .TP
 .BR Note
-The current version of pkcs11-sign-provider supports only the queue
+The current version of pkcs11\-sign\-provider supports only the queue
 parameters
-.IR pin-value " and"
-.IR pin-source .
+.IR pin\-value " and"
+.IR pin\-source .
 All other queue parameters are not yet supported.
 .PP
 
@@ -82,10 +82,10 @@ without a need-to-know.
 An application, which is using key material in a PKCS#11 token, has such a
 need-to-know, so the PIN should be under control of the application.
 .PP
-The pkcs11-sign-provider supports the PIN handling in the PKCS#11 URI with
+The pkcs11\-sign\-provider supports the PIN handling in the PKCS#11 URI with
 the queue attributes
-.IR pin-value " and"
-.IR pin-source .
+.IR pin\-value " and"
+.IR pin\-source .
 While the first one contains the plain-text PIN, the latter one refers to a
 file, which contains the PIN. It is highly recommended to use the file
 reference and set the access permissions of the PIN file accordingly.
@@ -118,7 +118,7 @@ user.
 PINFILE="/path/to/my_pinfile.txt"
 touch "${PINFILE}"
 chmod u=rw,g=,o= "${PINFILE}"
-(read -rsp "Enter PIN: " PIN; echo -n ${PIN}) > "${PINFILE}"
+(read \-rsp "Enter PIN: " PIN; echo \-n ${PIN}) > "${PINFILE}"
 .EE
 .in
 .PP

--- a/man/pkcs11sign.cnf.5
+++ b/man/pkcs11sign.cnf.5
@@ -1,10 +1,10 @@
-.TH PKCS11SIGN.CNF 5 "2023-05-17" "pkcs11sign.cnf"
+.TH PKCS11SIGN.CNF 5 "2024-05-14" "pkcs11sign.cnf"
 .SH NAME
 pkcs11sign.cnf \- Configuration for OpenSSL PKCS#11 sign provider module
 .PP
 
 .SH DESCRIPTION
-The pkcs11-sign-provider implements the OpenSSL 3.0 provider interface and
+The pkcs11\-sign\-provider implements the OpenSSL 3.0 provider interface and
 provides cryptographic operation on asymmetric key material, available in
 PKCS#11 infrastructure (e.g. opencryptoki). For more information see
 pkcs11sign(7).
@@ -12,20 +12,20 @@ pkcs11sign(7).
 
 .SH CONFIGURATION
 .SS OpenSSL Configuration
-The pkcs11-sign-provider can be configured application-specific or
+The pkcs11\-sign\-provider can be configured application-specific or
 system-wide. In both cases, the configuration file need to define and
-reference a section for the pkcs11-sign-provider, following the OpenSSL
+reference a section for the pkcs11\-sign\-provider, following the OpenSSL
 configuration syntax (config(5)).
 .PP
-The pkcs11-sign-provider section specifies the shared library of the
+The pkcs11\-sign\-provider section specifies the shared library of the
 provider itself (mandatory), the shared library of the Cryptoki
 implementation (mandatory) and initialization parameters for the Cryptoki
 implementation (optional). It is also possible to specify a forward
 provider. If no forward provider is specified, the OpenSSL built-in
 default-provider is selected.
 .PP
-The pkcs11-sign-provider must also be preferred in the algorithm-properties,
-so that all requests are directed to the pkcs11-sign-provider. This can
+The pkcs11\-sign\-provider must also be preferred in the algorithm-properties,
+so that all requests are directed to the pkcs11\-sign\-provider. This can
 either be done in the application or in the configuration file
 (recommended).
 .PP
@@ -34,7 +34,7 @@ either be done in the application or in the configuration file
 A provider section in the OpenSSL configuration define generic parameters,
 as well as provider-specific parameters. Each provider section can be
 references in a providers sections.
-The pkcs11-sign-provider requires at least the generic provider section
+The pkcs11\-sign\-provider requires at least the generic provider section
 parameters
 .IR module ,
 .IR identity ", and"
@@ -44,7 +44,7 @@ For more details about the generic provider parameters, see config(5).
 .TP
 .BR module " (mandatory)
 This parameter takes a path to the provider shared object file. For
-the pkcs11-sign-provider, use the path to the installation location of
+the pkcs11\-sign\-provider, use the path to the installation location of
 .I pkcs11sign.so
 (provider shared object).
 .TP
@@ -56,30 +56,30 @@ use the same name as in the providers.
 .BR activate " (optional)"
 If present, this parameter activates the provider section.
 .PP
-The pkcs11-sign-provider defines the provider specific parameters
-.IR pkcs11sign-module-path ,
-.IR pkcs11sign-module-init-args ", and"
-.IR pkcs11sign-forward .
+The pkcs11\-sign\-provider defines the provider specific parameters
+.IR pkcs11sign\-module\-path ,
+.IR pkcs11sign\-module\-init\-args ", and"
+.IR pkcs11sign\-forward .
 .TP
-.BR pkcs11sign-module-path " (mandatory)"
+.BR pkcs11sign\-module\-path " (mandatory)"
 This parameter takes the path to the shared object file of a PKCS#11
 Cryptoki module implementation. The provider can be used with PKCS#11
 Cryptoki modules, implementing the PKCS#11 standard version 3.0 (or
 compatible).
 .TP
-.BR pkcs11sign-forward " (optional)"
-The pkcs11sign-forward parameter takes the name of a provider, to which all
-operations are forwarded, which are not handled by the pkcs11-sign-provider
+.BR pkcs11sign\-forward " (optional)"
+The pkcs11sign\-forward parameter takes the name of a provider, to which all
+operations are forwarded, which are not handled by the pkcs11\-sign\-provider
 itself, e.g. key derivation for ECDHE. If this parameter is not specified in
-the provider section, the pkcs11-sign-provider will use the built-in OpenSSL
+the provider section, the pkcs11\-sign\-provider will use the built-in OpenSSL
 default provider as forward.
 .IP
 The syntax for this parameter is "provider=<name_of_forward_provider>". See
 the configuration example for more details.
 .PP
 .TP
-.BR pkcs11sign-module-init-args " (optional, not PKCS#11-3.0 conform)"
-The pkcs11sign-module-init-args takes a parameter string whose
+.BR pkcs11sign\-module\-init\-args " (optional, not PKCS#11-3.0 conform)"
+The pkcs11sign\-module\-init\-args takes a parameter string whose
 reference is passed to the Cryptoki module as
 .IR pReserved " in"
 .IR CK_C_INITIALIZE_ARGS
@@ -99,13 +99,13 @@ if this parameter is set.
 
 .SS EVP Configuration (alg_section)
 This section configures the algorithm-properties for the EVP API. The
-pkcs11-sign-provider should be set as the preferred provider for all EVP
+pkcs11\-sign\-provider should be set as the preferred provider for all EVP
 algorithms by adding the expression "?provider=pkcs11sign" to the
 .IR default_properties .
 .PP
 
 .SS Configuration example
-This example shows a pkcs11-sign-provider configuration for opencryptoki.
+This example shows a pkcs11\-sign\-provider configuration for opencryptoki.
 .in +4n
 .EX
 openssl_conf = openssl_init
@@ -125,15 +125,15 @@ default_properties = ?provider=pkcs11sign
 [pkcs11sign_sect]
 module = /path/to/pkcs11sign.so
 identity = pkcs11sign
-pkcs11sign-module-path = /path/to/libopencryptoki.so.0
-pkcs11sign-forward = provider=default
+pkcs11sign\-module\-path = /path/to/libopencryptoki.so.0
+pkcs11sign\-forward = provider=default
 activate = 1
 .EE
 .in
 .PP
 
 .SH ENVIRONMENT
-The pkcs11-sign-provider allows to generate a detailed log-file. The
+The pkcs11\-sign\-provider allows to generate a detailed log-file. The
 log-file generation can be enabled by setting the environment variable
 .IR PKCS11SIGN_DEBUG
 and
@@ -142,7 +142,7 @@ The internal logging is disabled, until the environment variables are set.
 .TP
 .B PKCS11SIGN_DEBUG
 This variable specifies the path to the log-file. If specified, it will
-enable the logging. The pkcs11-sign-provider will override an existing file
+enable the logging. The pkcs11\-sign\-provider will override an existing file
 in this location.
 .TP
 .B PKCS11SIGN_DEBUG_LEVEL


### PR DESCRIPTION
The typesetting programs troff or groff has a rendering for several "minus" or "dash" characters. Escape all characters in the man-pages, which should be rendered as hyphen-minus in any output. This affects e.g. parameters and attributes.