### PR TITLE
github: install missing pidof tool

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
--
+- various fixes and cleanups
+- update man-pages
 
 ## [1.0.1] - 2024-02-06
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - various fixes and cleanups
 - update man-pages
+- fix key management registration and key typing
 
 ## [1.0.1] - 2024-02-06
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - various fixes and cleanups
 - update man-pages
 - fix key management registration and key typing
+- fix several double frees
 
 ## [1.0.1] - 2024-02-06
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ material will be forwarded to an OpenSSL built-in provider.
 This project requires OpenSSL 3.0 or later, as well as opencryptoki.
 Support for other PKCS\#11 implementations is currently not available.
 
-The configuration step requires m4-macros of the autotools-archive project.
-It is recommended to install the autotools-archive package on the build
+The configuration step requires m4-macros of the autoconf-archive project.
+It is recommended to install the autoconf-archive package on the build
 system.
 
 To build the provider, use the following commands:

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1128,11 +1128,11 @@ static const OSSL_DISPATCH ps_keymgmt_functions_ec[] = {
 };
 
 const OSSL_ALGORITHM ps_keymgmt[] = {
-	{ "RSA:rsaEncryption", "provider="PS_PROV_NAME,
+	{ "RSA:rsaEncryption:1.2.840.113549.1.1.1", "provider="PS_PROV_NAME,
 				ps_keymgmt_functions_rsa, NULL },
-	{ "RSA-PSS:RSASSA-PSS", "provider="PS_PROV_NAME,
+	{ "RSA-PSS:RSASSA-PSS:1.2.840.113549.1.1.10", "provider="PS_PROV_NAME,
 				ps_keymgmt_functions_rsapss, NULL },
-	{ "EC:id-ecPublicKey", "provider="PS_PROV_NAME,
+	{ "EC:id-ecPublicKey:1.2.840.10045.2.1", "provider="PS_PROV_NAME,
 				ps_keymgmt_functions_ec, NULL },
 	{ NULL, NULL, NULL, NULL }
 };

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -900,7 +900,9 @@ int pkcs11_module_load(struct pkcs11_module *pkcs,
 
 close_err:
 	dlclose(pkcs->dlhandle);
+	pkcs->dlhandle = NULL;
 err:
 	OPENSSL_free(pkcs->soname);
+	pkcs->soname = NULL;
 	return OSSL_RV_ERR;
 }

--- a/src/store.c
+++ b/src/store.c
@@ -69,7 +69,7 @@ static int key2params(struct obj *obj, OSSL_PARAM *params, unsigned int nparams)
 		data_type = "RSA";
 		break;
 	case CKK_ECDSA:
-		data_type = "EC:id-ecPublicKey:1.2.840.10045.2.1";
+		data_type = "EC";
 		break;
 	default:
 		return OSSL_RV_ERR;


### PR DESCRIPTION
The ci is not working anymore. Maybe the upgrade to fc40 is somehow related.