### PR TITLE
Fixes for the store implementation

### DIFF
--- a/man/pkcs11sign.7
+++ b/man/pkcs11sign.7
@@ -100,8 +100,8 @@ Rules for the PIN file:
 .IP \[bu] 2
 one PIN per PIN file
 .IP \[bu]
-the PIN file must only contain the PIN, no comments, no linefeed or other
-characters
+the PIN file must only contain the PIN, no comments, but can contain linefeed
+or newline characters at the end.
 .IP \[bu]
 the PIN file must be readable by the application
 .IP \[bu]
@@ -118,7 +118,7 @@ user.
 PINFILE="/path/to/my_pinfile.txt"
 touch "${PINFILE}"
 chmod u=rw,g=,o= "${PINFILE}"
-(read \-rsp "Enter PIN: " PIN; echo \-n ${PIN}) > "${PINFILE}"
+(read \-rsp "Enter PIN: " PIN; echo ${PIN}) > "${PINFILE}"
 .EE
 .in
 .PP

--- a/src/debug.h
+++ b/src/debug.h
@@ -16,7 +16,7 @@
 #define DBG_INFO	(2)
 #define DBG_DEBUG	(3)
 
-inline bool ps_dbg_enabled(struct dbg *dbg)
+static inline bool ps_dbg_enabled(struct dbg *dbg)
 {
 	return (dbg) && (dbg->stream);
 }

--- a/src/uri.c
+++ b/src/uri.c
@@ -107,6 +107,14 @@ static char *retrieve_pin_from_file(const char *source)
 	if (rc <= 0)
 		goto err;
 
+	/* files may contain newlines, remove control characters at the end */
+	for (int i = rc - 1; i >= 0; i--) {
+		if (pin[i] == '\n' || pin[i] == '\r')
+			pin[i] = '\0';
+		else
+			break;
+	}
+
 	rv = OPENSSL_strndup(pin, MAX_PIN_LEN);
 err:
 	BIO_free(fp);


### PR DESCRIPTION
- Allow the pin-source file to have newline and linefeed at the end
- Avoid a loop when the PIN is wrong